### PR TITLE
Fix indent lint for recent change to member expressions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@
     }
   },
   "rules": {
+    "indent": [2, 4, { "MemberExpression": 0, 'SwitchCase': 1 }],
     "react/jsx-indent": [2, 4],
     "react/jsx-indent-props": [2, 4]
   }


### PR DESCRIPTION
Unfortunately there's no way in eslint to override specific rule options, so we needed to copy hapi's indent rule then add `"MemberExpression": 0`.