### PR TITLE
Recipe - `webrequest-loading-helper`

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ We use `react-router` [route definitions](https://github.com/reactjs/react-route
 )]
  - Incorporating server-side rendering (_very, very incomplete_) [[here](https://github.com/BigRoomStudios/strangeluv/compare/recipe-server-side
 )]
+ - Incorporating a 'webRequest loader' pattern using [axios](https://github.com/mzabriskie/axios) [[here](https://github.com/BigRoomStudios/strangeluv/compare/recipe-server-side
+)] -- This provides utilities to pass actions for in-flight, error, and success to be dispatched from a webRequest.
 
 ## Testing
 To add a unit test, simply create a `.spec.js` file anywhere in `tests/`. Karma will pick up on these files automatically, and Mocha and Chai will be available within your test without the need to import them. If you are using `redux-cli`, test files should automatically be generated when you create a component or redux module.

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "axios": "^0.16.1",
     "babel-cli": "^6.5.1",
     "babel-core": "^6.20.0",
     "babel-loader": "^6.2.0",

--- a/src/actions/utils.js
+++ b/src/actions/utils.js
@@ -1,5 +1,6 @@
 const WebClient = require('../utils/web-client');
-const utils = {} = exports;
+
+const utils = exports;
 
 utils.webRequest = (beginRequest, requestError, requestSuccess) => {
 

--- a/src/actions/utils.js
+++ b/src/actions/utils.js
@@ -1,0 +1,53 @@
+const WebClient = require('../utils/web-client');
+const utils = {} = exports;
+
+utils.webRequest = (beginRequest, complete, requestError) => {
+
+    return (method, url, data, cb) => {
+
+        method = method.toLowerCase();
+
+        if (method === 'get' && data) {
+            if (!data.params) {
+                throw new Error('Must provide `{ params: { myParam: 1 } }` if passing data to `get` requests');
+            }
+        }
+
+        // For get requests, data must be:
+        // `{ params: { userId: 1 } }`
+
+        // For posts and methods that require a payload:
+        // data is just the payload
+
+        if (typeof data === 'function') {
+            cb = data;
+            data = undefined;
+        }
+
+        return (dispatch) => {
+
+            dispatch(beginRequest());
+
+            const request = WebClient[method](url, data);
+
+            request.then((response) => {
+
+                if (!response || response.Error) {
+                    return dispatch(requestError(response));
+                }
+
+                // Looks good!
+                dispatch(complete(response));
+            })
+            .catch((err) => {
+
+                // Indicate that an error occurred
+                console.log(err);
+                dispatch(requestError(err));
+            });
+
+            // Pass-through the promise for testing purposes
+            return request;
+        };
+    };
+};

--- a/src/actions/utils.js
+++ b/src/actions/utils.js
@@ -14,7 +14,7 @@ utils.webRequest = (beginRequest, complete, requestError) => {
         }
 
         // For get requests, data must be:
-        // `{ params: { userId: 1 } }`
+        // `{ params: { myParam: 1 } }`
 
         // For posts and methods that require a payload:
         // data is just the payload

--- a/src/actions/utils.js
+++ b/src/actions/utils.js
@@ -1,7 +1,7 @@
 const WebClient = require('../utils/web-client');
 const utils = {} = exports;
 
-utils.webRequest = (beginRequest, complete, requestError) => {
+utils.webRequest = (beginRequest, requestError, requestSuccess) => {
 
     return (method, url, data, cb) => {
 
@@ -37,7 +37,7 @@ utils.webRequest = (beginRequest, complete, requestError) => {
                 }
 
                 // Looks good!
-                dispatch(complete(response));
+                dispatch(requestSuccess(response));
             })
             .catch((err) => {
 

--- a/src/utils/web-client.js
+++ b/src/utils/web-client.js
@@ -1,0 +1,44 @@
+const Axios = require('axios');
+
+const internals = {
+    host: process.env.API_HOST || 'http://localhost',
+    prefix: process.env.API_PREFIX || '',
+    getApiBase: () => {
+
+        const { host, prefix } = internals;
+
+        return `${host}${prefix}`;
+    }
+};
+
+const client = module.exports = Axios.create({
+    baseURL: internals.getApiBase(),
+    responseType: 'json',
+    headers: { common: {} }
+});
+
+client.batch = (requests) => {
+
+    const prefix = internals.prefix;
+
+    requests = requests.map((request) => {
+
+        return {
+            ...request,
+            path: `${prefix}${request.path}`
+        };
+    });
+
+    return client.post(internals.getApiBase(), { requests });
+};
+
+client.updateAuth = (newToken) => {
+
+    const headers = client.defaults.headers.common;
+
+    if (!newToken) {
+        return delete headers.authorization;
+    }
+
+    headers.authorization = `Bearer ${newToken}`;
+};


### PR DESCRIPTION
This recipe adds `src/utils/web-client.js` and `src/actions/utils.js` to give a 'loader request' interface: `beginRequest, error, success` for grabbing data from APIs