### PR TITLE
Recipe initial load action creator

### DIFF
--- a/src/action-types/moon-phase.js
+++ b/src/action-types/moon-phase.js
@@ -1,7 +1,7 @@
 const KeyMirror = require('keymirror');
 
 module.exports = KeyMirror({
-    MOON_LOAD_BEGIN: true,
-    MOON_LOADED: true,
-    MOON_LOAD_ERROR: true
+    MOON_LOAD_START: true,
+    MOON_LOAD_SUCCESS: true,
+    MOON_LOAD_FAIL: true
 });

--- a/src/actions/moon-phase.js
+++ b/src/actions/moon-phase.js
@@ -1,5 +1,4 @@
 const Axios = require('axios');
-const Types = require('../action-types/moon-phase');
 
 const actions = exports;
 

--- a/src/actions/moon-phase.js
+++ b/src/actions/moon-phase.js
@@ -3,32 +3,6 @@ const Types = require('../action-types/moon-phase');
 
 const actions = exports;
 
-// Marks the moment we start waiting for the moon phase
-actions.beginLoad = () => {
-
-    return {
-        type: Types.MOON_LOAD_BEGIN
-    };
-};
-
-// Marks the moment we've received some good info about the moon phase
-actions.loaded = (moon) => {
-
-    return {
-        type: Types.MOON_LOADED,
-        payload: moon
-    };
-};
-
-// Marks the moment an error occurred while look-up the moon phase
-actions.loadError = (error) => {
-
-    return {
-        type: Types.MOON_LOAD_ERROR,
-        payload: error
-    };
-};
-
 // We'll use a thunk to orchestrate the actions (listed above)
 // of this asynchronous process of hitting an API
 actions.load = () => {
@@ -36,34 +10,8 @@ actions.load = () => {
     // We'll want to lookup the moon phase for this very millisecond
     const now = Date.now();
 
-    return (dispatch) => {
-
-        // Indicate to the app that we're beginning to load the moon phase
-        dispatch(actions.beginLoad());
-
-        // Make a request to the Farmsense API
-        const getMoonPhase = Axios.get(`http://api.farmsense.net/v1/moonphases/?d=${now}`);
-
-        getMoonPhase.then((response) => {
-
-            // Format of response from Farmsense API looks like [{ ... }]
-            const result = response.data[0];
-
-            // Bad result
-            if (!result || result.Error) {
-                return dispatch(actions.loadError(result));
-            }
-
-            // Looks good!
-            dispatch(actions.loaded(result));
-        })
-        .catch((err) => {
-
-            // Indicate that an error occurred
-            dispatch(actions.loadError(err));
-        });
-
-        // Pass-through the promise for testing purposes
-        return getMoonPhase;
+    return {
+        callName: 'MOON_LOAD',
+        callAPI: () => Axios.get(`http://api.farmsense.net/v1/moonphases/?d=${now}`)
     };
 };

--- a/src/reducers/moon-phase.js
+++ b/src/reducers/moon-phase.js
@@ -17,17 +17,17 @@ module.exports = (state, action) => {
     const payload = action.payload;
 
     switch (type) {
-        case MoonPhaseTypes.MOON_LOAD_BEGIN:
+        case MoonPhaseTypes.MOON_LOAD_START:
             return Object.assign({}, state, {
                 isLoading: true
             });
-        case MoonPhaseTypes.MOON_LOADED:
+        case MoonPhaseTypes.MOON_LOAD_SUCCESS:
             return Object.assign({}, state, {
                 isLoading: false,
                 moonId: payload.Index,
                 error: null
             });
-        case MoonPhaseTypes.MOON_LOAD_ERROR:
+        case MoonPhaseTypes.MOON_LOAD_FAIL:
             return Object.assign({}, state, {
                 isLoading: false,
                 moonId: null,

--- a/src/wiring/api-middleware.js
+++ b/src/wiring/api-middleware.js
@@ -1,0 +1,68 @@
+const internals = {};
+
+internals.createSuccessAction = (moon, callName) => {
+
+    return {
+        type: callName + '_SUCCESS',
+        payload: moon
+    };
+};
+
+internals.createErrorAction = (error, callName) => {
+
+    return {
+        type: callName + '_FAIL',
+        payload: error
+    };
+};
+
+// adapted from https://redux.js.org/recipes/reducing-boilerplate
+module.exports = ({ dispatch, getState }) => {
+
+    return (next) => {
+
+        return (action) => {
+
+            const {
+                callName,
+                callAPI,
+                shouldCallAPI = () => true,
+                payload: payloadParams = {}
+            } = action;
+
+            if (!callAPI) {
+                // Normal action: pass it on
+                return next(action);
+            }
+
+            if (!shouldCallAPI(getState())) {
+                return;
+            }
+
+            dispatch({
+                type: callName + '_START',
+                payload: payloadParams
+            });
+
+            return callAPI().then(
+                (response) => {
+
+                    // Format of response from Farmsense API looks like [{ ... }]
+                    const result = response.data[0];
+
+                    // Bad result
+                    if (!result || result.Error) {
+                        return dispatch(internals.createErrorAction(result, callName));
+                    }
+
+                    // Looks good!
+                    dispatch(internals.createSuccessAction(result, callName));
+                },
+                (error) => {
+
+                    return dispatch(internals.createErrorAction(error, callName));
+                }
+            );
+        };
+    };
+};

--- a/src/wiring/middleware.js
+++ b/src/wiring/middleware.js
@@ -2,8 +2,10 @@ const Thunk = require('redux-thunk').default;
 const RouterMiddleware = require('react-router-redux').routerMiddleware;
 
 const History = require('./history');
+const APIMiddleware = require('./api-middleware');
 
 module.exports = [
     Thunk,
-    RouterMiddleware(History)
+    RouterMiddleware(History),
+    APIMiddleware
 ];


### PR DESCRIPTION
This implementation is based on [Redux's docs on reducing boilerplate](https://redux.js.org/recipes/reducing-boilerplate#async-action-creators).  The approach is to implement an API [middleware](https://redux.js.org/glossary#middleware) that listens for a new `callAPI` action type, shoots off the API request as well as the corresponding `start`, `success`, and `fail` actions.

This is not meant to be a perfect implementation of this, but as an example to illustrate this approach.