### PR TITLE
config tweak, prevent bunk login request on init

### DIFF
--- a/.env-keep
+++ b/.env-keep
@@ -1,0 +1,8 @@
+# Rename me to .env then fill me with runtime configuration and credentials
+# Just don't try to check me into your repo :)
+# Confused? See https://github.com/motdotla/dotenv
+#
+# e.g.
+NODE_ENV=dev
+API_HOST=
+API_PREFIX=

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 
 dist
 coverage
+
+.env

--- a/config/main.js
+++ b/config/main.js
@@ -76,7 +76,9 @@ Edit at Your Own Risk
 // N.B.: globals added here must _also_ be added to .eslintrc
 config.globals = {
     'process.env': {
-        NODE_ENV: JSON.stringify(config.env)
+        NODE_ENV: JSON.stringify(config.env),
+        API_HOST: JSON.stringify(process.env.API_HOST),
+        API_PREFIX: JSON.stringify(process.env.API_PREFIX)
     },
     NODE_ENV: config.env,
     __DEV__: config.env === 'dev',

--- a/src/initializers/auth.js
+++ b/src/initializers/auth.js
@@ -5,11 +5,6 @@ const AuthSelectors = require('selectors/auth');
 module.exports = (store) => {
 
     if (!LocalStorageAvailable()) {
-
-        // This forces strange-auth auth status to be set
-        // If no local storage, then we can determine there's no token
-        store.dispatch(AuthActions.login({ token: false }));
-
         return;
     }
 
@@ -48,5 +43,7 @@ module.exports = (store) => {
         }
     });
 
-    store.dispatch(AuthActions.login({ token }));
+    if (remember && token) {
+        store.dispatch(AuthActions.login({ token }));
+    }
 };

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -4,11 +4,7 @@ const Replace = require('react-router-redux').replace;
 
 exports.authenticate = connectedRouterRedirect({
     authenticatedSelector: (state) => state.auth.isAuthenticated,
-    authenticatingSelector: (state) => {
-
-        return (state.auth.status === AuthStatuses.INIT) ||
-               (state.auth.status === AuthStatuses.WAITING);
-    },
+    authenticatingSelector: (state) => (state.auth.status === AuthStatuses.WAITING),
     redirectPath: '/login',
     redirectAction: Replace,
     failureRedirectPath: '/',


### PR DESCRIPTION
yo! a few small dinks here.

- added a .env template file and set those vars in the main config, so you can configure the web client as you need

- made a hacky, ignorant tweak to the auth initializer. I made that change because on page load, if logged out, you'd see a login failed error, guessing b/c if local storage were available, the login action was fired off regardless of state of stuff in localStorage. I'm feeling 100% sure that this fucks some things up, shot it up here just to get ideas on paper. oh well, tried :trollface: 

otherwise, all's looking good I think. reset my password, got remembered and forgotten when I should have, signed in, logged in and logged out. thanks for all the work on this 🙏 
