### PR TITLE
Create settings page material

### DIFF
--- a/src/routes/forgot-password/components/ForgotPassword.js
+++ b/src/routes/forgot-password/components/ForgotPassword.js
@@ -26,8 +26,7 @@ module.exports = class ForgotPassword extends StrangeForms(React.Component) {
         this.strangeForm({
             fields: ['email'],
             get: (someProps, field) => this.state[field],
-            act: (field, value) => this.setState({ [field]: value }),
-            getFormValue: (e) => e.target.value || ''
+            act: (field, value) => this.setState({ [field]: value })
 
         });
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -6,6 +6,7 @@ const DashboardRoute = require('./dashboard');
 const SignupRoute = require('./signup');
 const ForgotPasswordRoute = require('./forgot-password');
 const ResetPasswordRoute = require('./reset-password');
+const SettingsRoute = require('./settings');
 
 // Create routes
 module.exports = (store) => ([{
@@ -17,6 +18,7 @@ module.exports = (store) => ([{
         DashboardRoute,
         SignupRoute,
         ForgotPasswordRoute,
-        ResetPasswordRoute
+        ResetPasswordRoute,
+        SettingsRoute
     ]
 }]);

--- a/src/routes/login/components/Login.js
+++ b/src/routes/login/components/Login.js
@@ -32,8 +32,8 @@ module.exports = class Login extends StrangeForms(React.Component) {
             get: (someProps, field) => this.state[field],
             act: (field, value) => this.setState({ [field]: value }),
             getFormValue: {
-                rememberMe: this.getCheckedValue.bind(this),
-                '*': this.getFormValue.bind(this)
+                rememberMe: (e) => e.target.checked,
+                '*': (e) => e.target.value || ''
             }
         });
 
@@ -42,16 +42,6 @@ module.exports = class Login extends StrangeForms(React.Component) {
         this.showPasswordError = this._showEmailError.bind(this);
         this.disableButton = this._disableButton.bind(this);
         this.submit = this._submit.bind(this);
-    }
-
-    getCheckedValue(e) {
-
-        return e.target.checked;
-    }
-
-    getFormValue(e) {
-
-        return e.target.value || '';
     }
 
     _fieldBlurred(ev) {

--- a/src/routes/reset-password/components/ResetPassword.js
+++ b/src/routes/reset-password/components/ResetPassword.js
@@ -30,8 +30,7 @@ module.exports = class ResetPassword extends StrangeForms(React.Component) {
         this.strangeForm({
             fields: ['email', 'password', 'confirmPassword'],
             get: (someProps, field) => this.state[field],
-            act: (field, value) => this.setState({ [field]: value }),
-            getFormValue: (e) => e.target.value || ''
+            act: (field, value) => this.setState({ [field]: value })
         });
 
         this.fieldBlurred = this._fieldBlurred.bind(this);

--- a/src/routes/settings/components/Settings.js
+++ b/src/routes/settings/components/Settings.js
@@ -39,10 +39,7 @@ module.exports = class Settings extends StrangeForms(React.Component) {
         this.strangeForm({
             fields: ['firstName', 'lastName', 'email', 'currentPassword', 'password', 'confirmPassword'],
             get: (someProps, field) => this.state[field],
-            act: (field, value) => this.setState({ [field]: value }),
-            getFormValue: {
-                '*': this.getFormValue.bind(this)
-            }
+            act: (field, value) => this.setState({ [field]: value })
         });
 
         this.fieldBlurred = this._fieldBlurred.bind(this);
@@ -50,16 +47,6 @@ module.exports = class Settings extends StrangeForms(React.Component) {
         this.showPasswordError = this._showPasswordError.bind(this);
         this.disableButton = this._disableButton.bind(this);
         this.submit = this._submit.bind(this);
-    }
-
-    getCheckedValue(e) {
-
-        return e.target.checked;
-    }
-
-    getFormValue(e) {
-
-        return e.target.value || '';
     }
 
     _fieldBlurred(ev) {
@@ -85,22 +72,17 @@ module.exports = class Settings extends StrangeForms(React.Component) {
     _disableButton() {
 
         const { firstName, lastName, email, currentPassword, password, confirmPassword } = this.state;
-        // const fieldHasValue = (firstName && lastName && email && password) !== '';
         const fieldHasChanged =
-            (firstName !== this.props.userDetails.firstName)
-            || (lastName !== this.props.userDetails.lastName)
-            || (email !== this.props.userDetails.email);
+            (firstName !== this.props.userDetails.firstName) ||
+            (lastName !== this.props.userDetails.lastName) ||
+            (email !== this.props.userDetails.email);
         const passwordsMatch = password === confirmPassword;
-        const requestPasswordChange = (password !== '')
-            && passwordsMatch
-            && (currentPassword !== password)
-            && (currentPassword !== '');
+        const requestPasswordChange = (password !== '') &&
+            passwordsMatch &&
+            (currentPassword !== password) &&
+            (currentPassword !== '');
 
-        // if (fieldHasValue && IsEmail(email) && passwordsMatch) {
-        //     return false;
-        // }
-
-        // TODO: Make sure this OR statement doesn't mess things up if something is half-filled or something
+        // When hooking this up, we'll want to make sure we only send relevant changes
         if (fieldHasChanged || (requestPasswordChange)) {
             return false;
         }
@@ -120,7 +102,6 @@ module.exports = class Settings extends StrangeForms(React.Component) {
     render() {
 
         return (
-
             <FormWrapper>
                 <form onSubmit={this.submit}>
                     <TextWrapper>

--- a/src/routes/settings/components/Settings.js
+++ b/src/routes/settings/components/Settings.js
@@ -37,11 +37,10 @@ module.exports = class Settings extends StrangeForms(React.Component) {
         };
 
         this.strangeForm({
-            fields: ['firstName', 'lastName', 'email', 'currentPassword', 'password', 'confirmPassword', 'rememberMe'],
+            fields: ['firstName', 'lastName', 'email', 'currentPassword', 'password', 'confirmPassword'],
             get: (someProps, field) => this.state[field],
             act: (field, value) => this.setState({ [field]: value }),
             getFormValue: {
-                rememberMe: this.getCheckedValue.bind(this),
                 '*': this.getFormValue.bind(this)
             }
         });
@@ -101,7 +100,8 @@ module.exports = class Settings extends StrangeForms(React.Component) {
         //     return false;
         // }
 
-        if (fieldHasChanged || requestPasswordChange) {
+        // TODO: Make sure this OR statement doesn't mess things up if something is half-filled or something
+        if (fieldHasChanged || (requestPasswordChange)) {
             return false;
         }
 
@@ -110,10 +110,9 @@ module.exports = class Settings extends StrangeForms(React.Component) {
 
     _submit(ev) {
 
-        const { firstName, lastName, email, password, rememberMe } = this.state;
+        const { firstName, lastName, email, password } = this.state;
 
         this.props.onSubmit({ email, password, firstName, lastName  });
-        this.props.rememberAct(rememberMe);
 
         ev.preventDefault();
     }
@@ -127,7 +126,7 @@ module.exports = class Settings extends StrangeForms(React.Component) {
                     <TextWrapper>
                         <Typography variant='headline' gutterBottom>Settings</Typography>
                         {this.props.errorMessage &&
-                            <FormHelperText>Oops, something went wrong! {this.props.errorMessage}</FormHelperText>
+                            <FormHelperText>Error: {this.props.errorMessage}</FormHelperText>
                         }
                         <TextField
                             id='firstName'

--- a/src/routes/settings/components/Settings.js
+++ b/src/routes/settings/components/Settings.js
@@ -1,0 +1,236 @@
+const React = require('react');
+const T = require('prop-types');
+const NavLink = require('react-router-dom').NavLink;
+const StrangeForms = require('strange-forms');
+const IsEmail = require('utils/is-email');
+const { Button, TextField, FormHelperText, Divider, Typography } = require('@material-ui/core');
+const { FormWrapper, TextWrapper, ButtonWrapper } = require('styles/global-components.js');
+
+
+module.exports = class Settings extends StrangeForms(React.Component) {
+
+    static propTypes = {
+        onSubmit: T.func.isRequired,
+        errorMessage: T.string,
+        userDetails: T.shape({
+            firstName: T.string.isRequired,
+            lastName: T.string.isRequired,
+            email: T.string.isRequired
+        })
+    };
+
+    constructor(props) {
+
+        super(props);
+
+        this.state = {
+            firstName: props.userDetails.firstName || '',
+            lastName: props.userDetails.lastName || '',
+            email: props.userDetails.email || '',
+            currentPassword: '',
+            password: '',
+            confirmPassword: '',
+            isBlurred: {
+                email: false,
+                confirmPassword: false
+            }
+        };
+
+        this.strangeForm({
+            fields: ['firstName', 'lastName', 'email', 'currentPassword', 'password', 'confirmPassword', 'rememberMe'],
+            get: (someProps, field) => this.state[field],
+            act: (field, value) => this.setState({ [field]: value }),
+            getFormValue: {
+                rememberMe: this.getCheckedValue.bind(this),
+                '*': this.getFormValue.bind(this)
+            }
+        });
+
+        this.fieldBlurred = this._fieldBlurred.bind(this);
+        this.showEmailError = this._showEmailError.bind(this);
+        this.showPasswordError = this._showPasswordError.bind(this);
+        this.disableButton = this._disableButton.bind(this);
+        this.submit = this._submit.bind(this);
+    }
+
+    getCheckedValue(e) {
+
+        return e.target.checked;
+    }
+
+    getFormValue(e) {
+
+        return e.target.value || '';
+    }
+
+    _fieldBlurred(ev) {
+
+        const isBlurred = { ...this.state.isBlurred };
+        const field = ev.target.id;
+
+        isBlurred[field] = true;
+
+        this.setState({ isBlurred });
+    }
+
+    _showEmailError() {
+
+        return (this.state.isBlurred.email) && !IsEmail(this.state.email);
+    }
+
+    _showPasswordError() {
+
+        return this.state.isBlurred.confirmPassword && (this.state.password !== this.state.confirmPassword);
+    }
+
+    _disableButton() {
+
+        const { firstName, lastName, email, currentPassword, password, confirmPassword } = this.state;
+        // const fieldHasValue = (firstName && lastName && email && password) !== '';
+        const fieldHasChanged =
+            (firstName !== this.props.userDetails.firstName)
+            || (lastName !== this.props.userDetails.lastName)
+            || (email !== this.props.userDetails.email);
+        const passwordsMatch = password === confirmPassword;
+        const requestPasswordChange = (password !== '')
+            && passwordsMatch
+            && (currentPassword !== password)
+            && (currentPassword !== '');
+
+        // if (fieldHasValue && IsEmail(email) && passwordsMatch) {
+        //     return false;
+        // }
+
+        if (fieldHasChanged || requestPasswordChange) {
+            return false;
+        }
+
+        return true;
+    }
+
+    _submit(ev) {
+
+        const { firstName, lastName, email, password, rememberMe } = this.state;
+
+        this.props.onSubmit({ email, password, firstName, lastName  });
+        this.props.rememberAct(rememberMe);
+
+        ev.preventDefault();
+    }
+
+    render() {
+
+        return (
+
+            <FormWrapper>
+                <form onSubmit={this.submit}>
+                    <TextWrapper>
+                        <Typography variant='headline' gutterBottom>Settings</Typography>
+                        {this.props.errorMessage &&
+                            <FormHelperText>Oops, something went wrong! {this.props.errorMessage}</FormHelperText>
+                        }
+                        <TextField
+                            id='firstName'
+                            type='text'
+                            variant='outlined'
+                            label='First Name'
+                            margin='normal'
+                            fullWidth
+                            value={this.fieldValue('firstName')}
+                            onChange={this.proposeNew('firstName')}
+                            onBlur={this.fieldBlurred}
+                        />
+                        <TextField
+                            id='lastName'
+                            type='text'
+                            variant='outlined'
+                            label='Last Name'
+                            margin='normal'
+                            fullWidth
+                            value={this.fieldValue('lastName')}
+                            onChange={this.proposeNew('lastName')}
+                            onBlur={this.fieldBlurred}
+                        />
+                        <TextField
+                            id='email'
+                            type='email'
+                            variant='outlined'
+                            label='Email'
+                            margin='normal'
+                            fullWidth
+                            value={this.fieldValue('email')}
+                            onChange={this.proposeNew('email')}
+                            onBlur={this.fieldBlurred}
+                            error={this.showEmailError()}
+                        />
+                        {this.showEmailError() &&
+                            <FormHelperText>
+                                Please enter a valid email address.
+                            </FormHelperText>
+                        }
+                    </TextWrapper>
+                    <TextWrapper>
+                        <Typography variant='subheading'>Change Password</Typography>
+                        <TextField
+                            id='currentPassword'
+                            type='password'
+                            variant='outlined'
+                            label='Current Password'
+                            margin='normal'
+                            fullWidth
+                            value={this.fieldValue('currentPassword')}
+                            onChange={this.proposeNew('currentPassword')}
+                        />
+                        <TextField
+                            id='password'
+                            type='password'
+                            variant='outlined'
+                            label='New Password'
+                            margin='normal'
+                            fullWidth
+                            value={this.fieldValue('password')}
+                            onChange={this.proposeNew('password')}
+                        />
+                        <TextField
+                            id='confirmPassword'
+                            type='password'
+                            variant='outlined'
+                            label='Confirm New Password'
+                            margin='normal'
+                            fullWidth
+                            value={this.fieldValue('confirmPassword')}
+                            onChange={this.proposeNew('confirmPassword')}
+                            onBlur={this.fieldBlurred}
+                            error={this.showPasswordError()}
+                        />
+                        {this.showPasswordError() &&
+                            <FormHelperText>
+                                Please enter matching passwords.
+                            </FormHelperText>
+                        }
+                    </TextWrapper>
+                    <ButtonWrapper>
+                        <Button
+                            variant='contained'
+                            type='submit'
+                            onClick={this.submit}
+                            disabled={this.disableButton()}
+                            color='primary'
+                            size='large'
+                        >Save Changes</Button>
+                    </ButtonWrapper>
+                    <TextWrapper>
+                        <Divider />
+                    </TextWrapper>
+                    <Button
+                        variant='text'
+                        size='small'
+                        component={(props) => <NavLink to='/forgot-password' {...props} />}
+                    >
+                        Forgot password?
+                    </Button>
+                </form>
+            </FormWrapper>
+        );
+    }
+};

--- a/src/routes/settings/containers/Settings.js
+++ b/src/routes/settings/containers/Settings.js
@@ -1,0 +1,23 @@
+const Connect = require('react-redux').connect;
+const Settings = require('../components/Settings');
+// const AuthAct = require('actions/auth');
+const AuthSelectors = require('selectors/auth');
+
+const internals = {};
+
+internals.connect = Connect(
+    (state) => ({
+        errorMessage: state.auth.error.message,
+        userDetails: {
+            firstName: AuthSelectors.getUserName(state),
+            lastName: AuthSelectors.getUserLastName(state),
+            email: AuthSelectors.getUserEmail(state)
+        }
+    }),
+    {
+        // onSubmit: AuthAct.registerUser
+        onSubmit: (console.log('Trying to submit on Settings page'))
+    }
+);
+
+module.exports = internals.connect(Settings);

--- a/src/routes/settings/containers/Settings.js
+++ b/src/routes/settings/containers/Settings.js
@@ -16,7 +16,7 @@ internals.connect = Connect(
     }),
     {
         // onSubmit: AuthAct.registerUser
-        onSubmit: (console.log('Trying to submit on Settings page'))
+        onSubmit: () => console.log('Trying to submit on Settings page')
     }
 );
 

--- a/src/routes/settings/index.js
+++ b/src/routes/settings/index.js
@@ -1,7 +1,8 @@
 const Settings = require('./containers/Settings');
+const Authenticate = require('../auth').authenticate;
 
 module.exports = {
     path: 'settings',
-    component: Settings,
+    component: Authenticate(Settings),
     exact: true
 };

--- a/src/routes/settings/index.js
+++ b/src/routes/settings/index.js
@@ -1,0 +1,7 @@
+const Settings = require('./containers/Settings');
+
+module.exports = {
+    path: 'settings',
+    component: Settings,
+    exact: true
+};

--- a/src/routes/signup/components/Signup.js
+++ b/src/routes/signup/components/Signup.js
@@ -37,8 +37,8 @@ module.exports = class Signup extends StrangeForms(React.Component) {
             get: (someProps, field) => this.state[field],
             act: (field, value) => this.setState({ [field]: value }),
             getFormValue: {
-                rememberMe: this.getCheckedValue.bind(this),
-                '*': this.getFormValue.bind(this)
+                rememberMe: (e) => e.target.checked,
+                '*': (e) => e.target.value || ''
             }
         });
 
@@ -47,16 +47,6 @@ module.exports = class Signup extends StrangeForms(React.Component) {
         this.showPasswordError = this._showPasswordError.bind(this);
         this.disableButton = this._disableButton.bind(this);
         this.submit = this._submit.bind(this);
-    }
-
-    getCheckedValue(e) {
-
-        return e.target.checked;
-    }
-
-    getFormValue(e) {
-
-        return e.target.value || '';
     }
 
     _fieldBlurred(ev) {

--- a/src/selectors/auth.js
+++ b/src/selectors/auth.js
@@ -1,6 +1,8 @@
 module.exports = {
 
     getUserName: (state) => state.auth.credentials.user.firstName,
+    getUserLastName: (state) => state.auth.credentials.user.lastName,
+    getUserEmail: (state) => state.auth.credentials.user.email,
     getIsAuthenticated: (state) => state.auth.isAuthenticated,
     getAuthStatus: (state) => state.auth.status,
     getShouldRemember: (state) => state.auth.remember,


### PR DESCRIPTION
Early progress based on [this Trello card](https://trello.com/c/PY3F20oZ/158-add-settings-page-to-material-auth-recipe). Largely copied from `signup`, this is waiting for an API endpoint to tie into, and will need a little more refinement once that's ready. I _did_ add some basic front-end validation to only allow a submission if a new, unique password is entered `or` if a name or email address changes, but I haven't gone as far as putting that all together in an object to send off. We also need to find an appropriate place to put a link to this settings page—let me know what you think.

Maybe it even makes sense to decompose some of this into a separate component to share with the `signup` route? Suggestions welcome!

Edit: Forgot to mention, testing this is sort of an adventure because strangeluv automatically redirects to `/dashboard` when authenticated, so you'll need to hit `/settings`, end up on `/dashboard`, and then user the browser's back button to see the settings page.