### PR TITLE
 Fix deep-linking when authenticated

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -63,19 +63,11 @@ exports.rememberMe = (remember) => ({
 
 // Login and Logout
 
-exports.login = ({ email, password, token }) => {
+exports.login = (...args) => {
 
     return (dispatch) => {
 
-        const strangeLogin = internals.strangeActions.login({ email, password, token });
-
-        return dispatch(strangeLogin)
-
-        .then(() => {
-
-            dispatch(Router.push('/dashboard'));
-        })
-        .catch(console.warn.bind(console));
+        return dispatch(internals.strangeActions.login(...args)).catch(console.warn);
     };
 };
 
@@ -185,7 +177,14 @@ internals.strangeActions = StrangeAuth.makeActions({
 
         const getToken = () => {
 
-            if (token) {
+            if (typeof token !== 'undefined') {
+
+                if (!token) {
+                    const error = new Error('No login token on init');
+                    error.code = 'NO_TOKEN_ON_INIT';
+                    return Promise.reject(error);
+                }
+
                 return Promise.resolve(token);
             }
 

--- a/src/initializers/auth.js
+++ b/src/initializers/auth.js
@@ -24,7 +24,7 @@ module.exports = (store) => {
     const remember = persistGet('remember') || false;
     const token = persistGet('token');
 
-    store.dispatch(AuthActions.rememberMe( remember ));
+    store.dispatch(AuthActions.rememberMe(remember));
 
     store.subscribe(() => {
 

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -46,6 +46,10 @@ module.exports = (state, action) => {
 
         case StrangeAuth.types.LOGIN_FAIL:
 
+            if (payload.code === 'NO_TOKEN_ON_INIT') {
+                return state;
+            }
+
             return Deeply(state)
                 .set('error.message', 'Login failed, please check your email and password.')
                 .value();

--- a/src/routes/login/containers/Login.js
+++ b/src/routes/login/containers/Login.js
@@ -16,7 +16,7 @@ internals.connect = Connect(
 
                 return Promise.resolve()
                 .then(() => dispatch(AuthAct.login(...args)))
-                .then(() => dispatch(Router.push('/dashboard')));
+                .then((success) => success && dispatch(Router.push('/dashboard')));
             };
         },
         rememberAct: AuthAct.rememberMe

--- a/src/routes/login/containers/Login.js
+++ b/src/routes/login/containers/Login.js
@@ -1,6 +1,7 @@
 const Connect = require('react-redux').connect;
 const Login = require('../components/Login');
 const AuthAct = require('actions/auth');
+const Router = require('react-router-redux');
 
 const internals = {};
 
@@ -9,7 +10,15 @@ internals.connect = Connect(
         errorMessage: state.auth.error.message
     }),
     {
-        login: AuthAct.login,
+        login: (...args) => {
+
+            return (dispatch) => {
+
+                return Promise.resolve()
+                .then(() => dispatch(AuthAct.login(...args)))
+                .then(() => dispatch(Router.push('/dashboard')));
+            };
+        },
         rememberAct: AuthAct.rememberMe
     }
 );


### PR DESCRIPTION
The login action invariably caused the user to be directed to the `/dashboard`.  Now the login action performs no redirection, and the caller can decide whether or not to do that on their own.  I also fixed a minor issue where settling login state required a network request even if no token was remembered.