### PR TITLE
Passed theme into App component and showed example usage

### DIFF
--- a/src/components/GlobalStyle.js
+++ b/src/components/GlobalStyle.js
@@ -1,9 +1,0 @@
-const Styled = require('styled-components');
-const NormalizeMixin = require('polished/lib/mixins/normalize');
-
-module.exports = Styled.createGlobalStyle`
-    ${NormalizeMixin()}
-    body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-    }
-`;

--- a/src/components/GlobalStyle.js
+++ b/src/components/GlobalStyle.js
@@ -1,0 +1,9 @@
+const Styled = require('styled-components');
+const NormalizeMixin = require('polished/lib/mixins/normalize');
+
+module.exports = Styled.createGlobalStyle`
+    ${NormalizeMixin()}
+    body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    }
+`;

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const React = require('react');
 const ReactDOM = require('react-dom');
 const M = require('./middle-end');
 const App = require('./App');
+const Theme = require('./theme');
 
 (() => {
 
@@ -17,6 +18,7 @@ const App = require('./App');
         <App
             store={M.store}
             history={M.mods.router.history}
+            theme={Theme}
         />,
         document.getElementById('root')
     );

--- a/src/routes/home/components/HomePage.js
+++ b/src/routes/home/components/HomePage.js
@@ -7,11 +7,11 @@ const internals = {};
 
 module.exports = () => {
 
-    const { Image, HomepageContainer } = internals;
+    const { Image, HomepageContainer, WelcomeMessage } = internals;
 
     return (
         <HomepageContainer>
-            <Typography variant='h4' align='center'>Welcome!</Typography>
+            <WelcomeMessage variant='h4' align='center'>Welcome!</WelcomeMessage>
             <Image
                 alt='This is a duck, because Redux!'
                 src={DuckImage}
@@ -29,4 +29,10 @@ internals.Image = Styled.img`
 internals.HomepageContainer = Styled.div`
     align-self: center;
     margin: auto;
+`;
+
+internals.WelcomeMessage = Styled(Typography).attrs({ variant: 'h4', align: 'center' })`
+
+    // Example leveraging the mui theme from styled-components
+    color: ${(props) => props.theme.palette.duckYellow.main};
 `;

--- a/src/routes/home/components/HomePage.js
+++ b/src/routes/home/components/HomePage.js
@@ -34,5 +34,5 @@ internals.HomepageContainer = Styled.div`
 internals.WelcomeMessage = Styled(Typography).attrs({ variant: 'h4', align: 'center' })`
 
     // Example leveraging the mui theme from inside a styled-component
-    color: ${(props) => props.theme.palette.duckYellow.main};
+    color: ${({ theme }) => theme.palette.duckYellow.main};
 `;

--- a/src/routes/home/components/HomePage.js
+++ b/src/routes/home/components/HomePage.js
@@ -11,7 +11,7 @@ module.exports = () => {
 
     return (
         <HomepageContainer>
-            <WelcomeMessage variant='h4' align='center'>Welcome!</WelcomeMessage>
+            <WelcomeMessage>Welcome!</WelcomeMessage>
             <Image
                 alt='This is a duck, because Redux!'
                 src={DuckImage}
@@ -33,6 +33,6 @@ internals.HomepageContainer = Styled.div`
 
 internals.WelcomeMessage = Styled(Typography).attrs({ variant: 'h4', align: 'center' })`
 
-    // Example leveraging the mui theme from styled-components
+    // Example leveraging the mui theme from inside a styled-component
     color: ${(props) => props.theme.palette.duckYellow.main};
 `;

--- a/src/routes/home/components/HomePage.js
+++ b/src/routes/home/components/HomePage.js
@@ -34,5 +34,5 @@ internals.HomepageContainer = Styled.div`
 internals.WelcomeMessage = Styled(Typography).attrs({ variant: 'h4', align: 'center' })`
 
     // Example leveraging the mui theme from inside a styled-component
-    color: ${({ theme }) => theme.palette.duckYellow.main};
+    color: ${({ theme }) => theme.palette.secondary.main};
 `;

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,3 +1,12 @@
 const { default: CreateMuiTheme } = require('@material-ui/core/styles/createMuiTheme');
 
-module.exports = CreateMuiTheme({});
+module.exports = CreateMuiTheme({
+    palette: {
+        duckYellow: {
+            main: '#EED663'
+        }
+    },
+    typography: {
+        fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"'
+    }
+});

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,5 +1,5 @@
 const { default: CreateMuiTheme } = require('@material-ui/core/styles/createMuiTheme');
-const { default: amber } = require('@material-ui/core/colors/amber');
+const { default: Amber } = require('@material-ui/core/colors/amber');
 
 module.exports = CreateMuiTheme({
     palette: {

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,6 +1,10 @@
 const { default: CreateMuiTheme } = require('@material-ui/core/styles/createMuiTheme');
 const { default: Amber } = require('@material-ui/core/colors/amber');
 
+// The object below overrides specific values and/or extends the default material-ui theme, which can currently be found here: https://material-ui.com/customization/default-theme/#default-theme
+
+// Any of the values in that default theme may be used throughout this project, even if they aren't explicitly defined here (e.g., `theme.shape.borderRadius` will return 4, even though `shape` isn't currently defined in this file)
+
 module.exports = CreateMuiTheme({
     palette: {
         secondary: {

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,9 +1,10 @@
 const { default: CreateMuiTheme } = require('@material-ui/core/styles/createMuiTheme');
+const { default: amber } = require('@material-ui/core/colors/amber');
 
 module.exports = CreateMuiTheme({
     palette: {
-        duckYellow: {
-            main: '#EED663'
+        secondary: {
+            main: amber[500]
         }
     },
     typography: {

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,15 +1,14 @@
 const { default: CreateMuiTheme } = require('@material-ui/core/styles/createMuiTheme');
 const { default: Amber } = require('@material-ui/core/colors/amber');
 
-// The object below overrides specific values and/or extends the default material-ui theme, which can currently be found here: https://material-ui.com/customization/default-theme/#default-theme
-
-// Any of the values in that default theme may be used throughout this project, even if they aren't explicitly defined here (e.g., `theme.shape.borderRadius` will return 4, even though `shape` isn't currently defined in this file)
+// The object below overrides specific values and/or extends the default material-ui theme, which can currently be found here:
+// https://material-ui.com/customization/default-theme/#default-theme
+// Any of the values in that default theme may be used throughout this project, even if they aren't explicitly defined here
+// (e.g., `theme.shape.borderRadius` will return 4, even though `shape` isn't currently defined in this file)
 
 module.exports = CreateMuiTheme({
     palette: {
-        secondary: {
-            main: amber[500]
-        }
+        secondary: Amber
     },
     typography: {
         fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"'


### PR DESCRIPTION
Adds a few things that were missing from the v2-mui branch, like passing the theme component through props to the App component in `index.js` and showing a few examples with the mui-theme and styled-components.