### PR TITLE
Create login view

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,4 +1,5 @@
 const React = require('react');
+const T = require('prop-types');
 const { NavLink } = require('react-router-dom');
 const { default: Styled } = require('styled-components');
 const { default: Typography } = require('@material-ui/core/Typography');
@@ -8,9 +9,10 @@ const { default: Button } = require('@material-ui/core/Button');
 
 const internals = {};
 
-module.exports = () => {
+module.exports = (props) => {
 
     const { Link, SiteTitle } = internals;
+    const { isAuthenticated, logout } = props;
 
     return (
         <AppBar position='static'>
@@ -18,6 +20,7 @@ module.exports = () => {
                 <SiteTitle>Strangeluv</SiteTitle>
                 <Link exact to='/'>Home</Link>
                 <Link to='/counter'>Counter</Link>
+                {isAuthenticated && <Button color='inherit' onClick={logout}>Logout</Button>}
             </Toolbar>
         </AppBar>
     );
@@ -33,3 +36,10 @@ internals.Link = Styled(Button).attrs({ component: NavLink, color: 'inherit' })`
 internals.SiteTitle = Styled(Typography).attrs({ variant: 'h6' })`
     flex-grow: 1;
 `;
+
+module.exports.displayName = 'Header';
+
+module.exports.propTypes = {
+    isAuthenticated: T.bool,
+    logout: T.func.isRequired
+};

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -8,13 +8,13 @@ const { default: ErrorBoundary } = require('react-error-boundary');
 
 const internals = {};
 
-module.exports = ({ children, location }) => {
+module.exports = ({ children, location, isAuthenticated, logout }) => {
 
     const { Container, AppContainer } = internals;
 
     return (
         <AppContainer>
-            <Header />
+            <Header isAuthenticated={isAuthenticated} logout={logout} />
             <Container>
                 <ErrorBoundary key={location.key} FallbackComponent={ErrorFallback}>
                     <React.Suspense fallback={<LoadingFallback />}>
@@ -30,7 +30,9 @@ module.exports.propTypes = {
     children: T.any,
     location: T.shape({
         key: T.string
-    })
+    }),
+    isAuthenticated: T.bool,
+    logout: T.func.isRequired
 };
 
 internals.Container = Styled.div`

--- a/src/containers/Layout.js
+++ b/src/containers/Layout.js
@@ -1,6 +1,6 @@
 const Connect = require('react-redux').connect;
-const LoginPage = require('../components/LoginPage');
-const M = require('../../../middle-end');
+const Layout = require('../components/Layout');
+const M = require('../middle-end');
 
 const internals = {};
 
@@ -9,13 +9,12 @@ internals.connect = Connect(
         isAuthenticated: M.selectors.auth.getIsAuthenticated(state)
     }),
     (dispatch) => ({
-        reqCreateAccount: async ( loginInfo ) => {
+        logout: async () => {
 
-            const [err, result] = await M.dispatch.auth.login(loginInfo);
-
+            const [err, result] = await M.dispatch.auth.logout();
             return [err, result];
         }
     })
 );
 
-module.exports = internals.connect(LoginPage);
+module.exports = internals.connect(Layout);

--- a/src/middle-end/auth/action-types.js
+++ b/src/middle-end/auth/action-types.js
@@ -2,5 +2,6 @@ const MiddleEnd = require('strange-middle-end');
 
 module.exports = MiddleEnd.createTypes('auth', {
     CREATE_ACCOUNT: MiddleEnd.type.async,
-    LOGIN: MiddleEnd.type.async
+    LOGIN: MiddleEnd.type.async,
+    LOGOUT: MiddleEnd.type.async
 });

--- a/src/middle-end/auth/actions.js
+++ b/src/middle-end/auth/actions.js
@@ -1,5 +1,5 @@
 const MiddleEnd = require('strange-middle-end');
-const { CREATE_ACCOUNT, LOGIN } = require('./action-types');
+const { CREATE_ACCOUNT, LOGIN, LOGOUT } = require('./action-types');
 const WebClient = require('../../utils/web-client');
 
 const internals = {};
@@ -18,6 +18,15 @@ exports.login = MiddleEnd.createAction(LOGIN, {
     handler: async (loginInfo) => {
 
         const { data: results } = await WebClient.post('/login', loginInfo);
+        return results;
+    }
+});
+
+exports.logout = MiddleEnd.createAction(LOGOUT, {
+    index: true,
+    handler: async () => {
+
+        const { data: results } = await WebClient.post('/logout');
         return results;
     }
 });

--- a/src/middle-end/auth/actions.js
+++ b/src/middle-end/auth/actions.js
@@ -19,11 +19,16 @@ exports.login = MiddleEnd.createAction(LOGIN, {
 
         const { data: results } = await WebClient.post('/login', loginInfo);
         return results;
+    },
+    after: ({ result }) => {
+
+        const { token } = result;
+        WebClient.updateAuth({ token });
     }
 });
 
 exports.logout = MiddleEnd.createAction(LOGOUT, {
-    index: true,
+    index: LOGIN.BASE,
     handler: async () => {
 
         const { data: results } = await WebClient.post('/logout');

--- a/src/middle-end/auth/index.js
+++ b/src/middle-end/auth/index.js
@@ -1,3 +1,5 @@
 module.exports = {
-    actions: require('./actions')
+    actions: require('./actions'),
+    reducer: require('./reducer'),
+    selectors: require('./selectors')
 };

--- a/src/middle-end/auth/reducer.js
+++ b/src/middle-end/auth/reducer.js
@@ -1,0 +1,3 @@
+const MiddleEnd = require('strange-middle-end');
+
+module.exports = MiddleEnd.createEntityReducer({ shouldIndex: (indexName) => indexName.startsWith('auth/') });

--- a/src/middle-end/auth/selectors.js
+++ b/src/middle-end/auth/selectors.js
@@ -1,0 +1,23 @@
+const { LOGIN } = require('./action-types');
+
+exports.getIsAuthenticated = ({ auth }) => {
+
+    const { [LOGIN.BASE]: index } = auth.indexes;
+
+    if (!index) {
+        return false;
+    }
+
+    // bigroomstudios/strange-middle-end#8 will allow us to determine the type of action (i.e., login or logout)
+    // instead of checking for the payload shape
+    const isLoginPayload = (payload) => {
+
+        return ['email', 'password'].every((key) => Object.keys(payload).includes(key));
+    };
+
+    if (!isLoginPayload(index.original || {})) {
+        return false;
+    }
+
+    return !!(index.result && !index.error);
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const Layout = require('../components/Layout');
+const Layout = require('../containers/Layout');
 const NotFoundPage = require('../components/NotFoundPage');
 const NotFoundHelpers = require('./helpers/not-found');
 const HomePage = require('./home/components/HomePage');

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -4,6 +4,7 @@ const NotFoundPage = require('../components/NotFoundPage');
 const NotFoundHelpers = require('./helpers/not-found');
 const HomePage = require('./home/components/HomePage');
 const SignupPage = require('./join/containers/SignupPage');
+const LoginPage = require('./login/containers/LoginPage');
 
 const CounterPage = React.lazy(() => import('./counter/containers/CounterPage'));
 
@@ -25,6 +26,11 @@ module.exports = [
             {
                 path: 'join',
                 component: SignupPage,
+                exact: true
+            },
+            {
+                path: 'login',
+                component: LoginPage,
                 exact: true
             },
             NotFoundHelpers.CatchAllRoute

--- a/src/routes/join/components/SignupPage.js
+++ b/src/routes/join/components/SignupPage.js
@@ -67,7 +67,12 @@ module.exports = class SignupPage extends StrangeForms(React.Component) {
 
     disableSubmit() {
 
-        return false;
+        const firstName = this.fieldValue('firstName');
+        const lastName = this.fieldValue('lastName');
+        const email = this.fieldValue('email');
+        const password = this.fieldValue('password');
+
+        return !firstName || !lastName || !email || !password;
     }
 
     handleSubmit = async (ev) => {

--- a/src/routes/join/components/SignupPage.js
+++ b/src/routes/join/components/SignupPage.js
@@ -5,7 +5,7 @@ const { default: Typography } = require('@material-ui/core/Typography');
 const { default: TextField } = require('@material-ui/core/TextField');
 const { default: Button } = require('@material-ui/core/Button');
 const { default: Box } = require('@material-ui/core/Box');
-const { default: Link } = require('@material-ui/core/Link');
+const { NavLink } = require('react-router-dom');
 const { default: FormControl } = require('@material-ui/core/FormControl');
 const { default: InputLabel } = require('@material-ui/core/InputLabel');
 const { default: Input } = require('@material-ui/core/Input');
@@ -161,7 +161,7 @@ module.exports = class SignupPage extends StrangeForms(React.Component) {
                         >
                             Sign Up
                         </Button>
-                        <Typography variant='body2'>Have an account? <Link href='/login'>Log In</Link></Typography>
+                        <Typography variant='body2'>Have an account? <NavLink to='/login'>Log In</NavLink></Typography>
                     </Box>
                 </StyledForm>
             </PageContainer>

--- a/src/routes/login/components/LoginPage.js
+++ b/src/routes/login/components/LoginPage.js
@@ -1,0 +1,120 @@
+const React = require('react');
+const T = require('prop-types');
+const { default: Styled } = require('styled-components');
+const { default: Typography } = require('@material-ui/core/Typography');
+const { default: TextField } = require('@material-ui/core/TextField');
+const { default: Button } = require('@material-ui/core/Button');
+const { default: Box } = require('@material-ui/core/Box');
+const { default: Link } = require('@material-ui/core/Link');
+const StrangeForms = require('strange-forms');
+
+const internals = {};
+
+module.exports = class LoginPage extends StrangeForms(React.Component) {
+
+    static propTypes = {
+        reqCreateAccount: T.func.isRequired
+    };
+
+    static fields = {
+        email: '',
+        password: ''
+    };
+
+    constructor(props) {
+
+        super(props);
+
+        this.state = {
+            email: '',
+            password: '',
+            isSubmitting: false
+        };
+
+        this.strangeForm({
+            fields: Object.keys(LoginPage.fields),
+            get: (someProps, field) => {
+
+                return someProps.data ? someProps.data[field] : '';
+            },
+            act: () => null
+        });
+    }
+
+    disableSubmit() {
+
+        return !this.fieldValue('password') || !this.fieldValue('email');
+    }
+
+    handleSubmit = async (ev) => {
+
+        ev.preventDefault();
+        const accountInfo = this.formatFields();
+        this.setState({ isSubmitting: true });
+        const [err] = await this.props.reqCreateAccount(accountInfo);
+        this.setState({ isSubmitting: false });
+        if (!err) {
+            // Login and redirect
+        }
+    }
+
+    formatFields = () => {
+
+        return {
+            email: this.fieldValue('email'),
+            password: this.fieldValue('password')
+        };
+    };
+
+    render() {
+
+        const { isSubmitting } = this.state;
+        const { PageContainer, StyledForm } = internals;
+
+        return (
+            <PageContainer>
+                <Typography variant='h4' align='center' gutterBottom>Log In</Typography>
+                <StyledForm onSubmit={this.handleSubmit}>
+                    <TextField
+                        required
+                        type='email'
+                        label='Email'
+                        value={this.fieldValue('email')}
+                        onChange={this.proposeNew('email')}
+                    />
+                    <TextField
+                        required
+                        type='password'
+                        label='Password'
+                        value={this.fieldValue('password')}
+                        onChange={this.proposeNew('password')}
+                    />
+                    <Box
+                        my={2}
+                    >
+                        <Button
+                            type='submit'
+                            variant='contained'
+                            color='primary'
+                            fullWidth
+                            disabled={this.disableSubmit() || isSubmitting}
+                        >
+                            Log In
+                        </Button>
+                        <Typography variant='body2'>Don't have an account? <Link href='/join'>Sign up</Link></Typography>
+                    </Box>
+                </StyledForm>
+            </PageContainer>
+        );
+    }
+};
+
+internals.StyledForm = Styled.form`
+    display: flex;
+    flex-direction: column;
+`;
+
+internals.PageContainer = Styled.div`
+    align-self: center;
+    margin: auto;
+`;

--- a/src/routes/login/components/LoginPage.js
+++ b/src/routes/login/components/LoginPage.js
@@ -34,10 +34,7 @@ module.exports = class LoginPage extends StrangeForms(React.Component) {
 
         this.strangeForm({
             fields: Object.keys(LoginPage.fields),
-            get: (someProps, field) => {
-
-                return someProps.data ? someProps.data[field] : '';
-            },
+            get: () => '',
             act: () => null
         });
     }

--- a/src/routes/login/components/LoginPage.js
+++ b/src/routes/login/components/LoginPage.js
@@ -1,11 +1,11 @@
 const React = require('react');
 const T = require('prop-types');
+const { NavLink } = require('react-router-dom');
 const { default: Styled } = require('styled-components');
 const { default: Typography } = require('@material-ui/core/Typography');
 const { default: TextField } = require('@material-ui/core/TextField');
 const { default: Button } = require('@material-ui/core/Button');
 const { default: Box } = require('@material-ui/core/Box');
-const { default: Link } = require('@material-ui/core/Link');
 const StrangeForms = require('strange-forms');
 
 const internals = {};
@@ -13,7 +13,8 @@ const internals = {};
 module.exports = class LoginPage extends StrangeForms(React.Component) {
 
     static propTypes = {
-        reqCreateAccount: T.func.isRequired
+        reqCreateAccount: T.func.isRequired,
+        isAuthenticated: T.bool
     };
 
     static fields = {
@@ -101,7 +102,7 @@ module.exports = class LoginPage extends StrangeForms(React.Component) {
                         >
                             Log In
                         </Button>
-                        <Typography variant='body2'>Don't have an account? <Link href='/join'>Sign up</Link></Typography>
+                        <Typography variant='body2'>Don't have an account? <NavLink to='/join'>Sign up</NavLink></Typography>
                     </Box>
                 </StyledForm>
             </PageContainer>

--- a/src/routes/login/containers/LoginPage.js
+++ b/src/routes/login/containers/LoginPage.js
@@ -1,0 +1,19 @@
+const Connect = require('react-redux').connect;
+const LoginPage = require('../components/LoginPage');
+const M = require('../../../middle-end');
+
+const internals = {};
+
+internals.connect = Connect(
+    (state) => ({}),
+    (dispatch) => ({
+        reqCreateAccount: async ( loginInfo ) => {
+
+            const [err, result] = await M.dispatch.auth.login(loginInfo);
+
+            return [err, result];
+        }
+    })
+);
+
+module.exports = internals.connect(LoginPage);

--- a/src/utils/web-client.js
+++ b/src/utils/web-client.js
@@ -6,9 +6,9 @@ const client = module.exports = Axios.create({
     headers: { common: {} }
 });
 
-client.updateConfiguration = ({ apiBaseUrl, ...rest }) => {
+client.updateAuth = ({ token }) => {
 
-    if (apiBaseUrl || apiBaseUrl === '') {
-        client.defaults.baseURL = apiBaseUrl;
-    }
+    const headers = client.defaults.headers.common;
+
+    return Object.assign(headers, { authorization: `Bearer ${token}` });
 };


### PR DESCRIPTION
Creates a `/login` view and allows a user to log in and log out.

The test is currently failing because the middle-end used in the test is different than the middle-end used in `containers/Layout.js`. Devin says this is a tricky pain-in-the-butt problem, so I'm not going to worry about that right now.

As a placeholder, when the user is authenticated, a logout button appears in the header. We can handle this any number of ways, though:

- Add a login button in the header when the user is not authenticated
- Add login/signup buttons to the homepage
- Add login/signup fields to the homepage
- Add a ︙ menu to the header with a log in or log out option beneath it
- Add a logout icon in lieu of a logout button

There's also a line that can be changed after a new feature is implemented in `strange-middle-end`.