### PR TITLE
CDK static site deployment

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 build
+cdk.out

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 build
 coverage
 config/.env
+cdk.context.json
+cdk.out

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ $ npm start                     # Start development server
 ## Application Structure
 ```
 .
+├── cdk/                     # CDK deployment files
+│   └── index.js             # entry point for CDK, as defined in cdk.json
+│   └── static-site.js       # CDK code needed to spin up a new static site
 ├── config/                  # Project configuration settings
 │   └── index.js             # Configuration entrypoint
 ├── server/                  # hapi server/plugin for production
@@ -95,6 +98,20 @@ Runs a hapi server located in `server/` setup to serve the `build/` directory pl
 
 ### As a hapi plugin
 The production deployment can also be served as a hapi plugin, located in `server/plugin.js`.
+
+### Static Site Deployment with Amazon CDK
+This example was created based on the [CDK Static Site Example](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/static-site). Below are steps to get setup. IMPORTANT: before following them, update your `cdk.json` file, replacing dummy parameters with real ones for your account and site.
+
+```bash
+$ sudo pip3 install awscli      # Install AWS CLI locally
+$ aws configure                 # Setup AWS creds, you'll need info from your IAM role
+$ cdk bootstrap
+$ cdk deploy                    # deploy -- this is a long process that will take about 40 minutes
+```
+Other helpful CDK commands:
+
+* `cdk synth` outputs the CloudFormation configuration your CDK code produces
+* `cdk diff` outputs what infrastructure changes would be made by executing this deployment
 
 ## Thank You
 * [Dave Zuko](https://github.com/davezuko) - for creating the [boilerplate](https://github.com/davezuko/react-redux-starter-kit) that we forked (at v3).  It contains a huge amount of effort from dozens of collaborators, and made for a fantastic start.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The production deployment can also be served as a hapi plugin, located in `serve
 This example was created based on the [CDK Static Site Example](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/static-site). Below are steps to get setup. IMPORTANT: before following them, update your `cdk.json` file, replacing dummy parameters with real ones for your account and site.
 
 ```bash
+$ npm run build                 # Create a build of the site
 $ sudo pip3 install awscli      # Install AWS CLI locally
 $ aws configure                 # Setup AWS creds, you'll need info from your IAM role
 $ cdk bootstrap

--- a/cdk.json
+++ b/cdk.json
@@ -1,0 +1,8 @@
+{
+    "app": "node ./cdk/index",
+    "context": {
+        "account": "123456789123",
+        "domain": "example.com",
+        "subdomain": "sub-domain"
+    }
+}

--- a/cdk/index.js
+++ b/cdk/index.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const CDK = require('@aws-cdk/core');
+const { StaticSite } = require('./static-site');
+
+/**
+ * This stack relies on getting the domain name from CDK context.
+ * Use 'cdk synth -c domain=mystaticsite.com -c subdomain=www'
+ * Or add the following to cdk.json:
+ * {
+ *   "context": {
+ *     "domain": "mystaticsite.com",
+ *     "subdomain": "www"
+ *   }
+ * }
+**/
+class MyStaticSiteStack extends CDK.Stack {
+    constructor(parent, name, props) {
+
+        super(parent, name, props);
+
+        new StaticSite(this, 'StaticSite', {
+            domainName: this.node.tryGetContext('domain'),
+            siteSubDomain: this.node.tryGetContext('subdomain')
+        });
+    }
+}
+
+const app = new CDK.App();
+
+new MyStaticSiteStack(app, 'StrangeluvStaticSite', {
+    env: {
+        // Stack must be in us-east-1, because the ACM certificate for a
+        // global CloudFront distribution must be requested in us-east-1.
+        region: 'us-east-1',
+        account: app.node.tryGetContext('account')
+    }
+});
+
+app.synth();

--- a/cdk/static-site.js
+++ b/cdk/static-site.js
@@ -55,6 +55,13 @@ class StaticSite extends Core.Construct {
                     },
                     behaviors: [{ isDefaultBehavior: true }]
                 }
+            ],
+            errorConfigurations: [
+                {
+                    errorCode: 403,
+                    responseCode: 404,
+                    responsePagePath: '/index.html'
+                }
             ]
         });
         new CDK.CfnOutput(this, 'DistributionId', { value: distribution.distributionId });

--- a/cdk/static-site.js
+++ b/cdk/static-site.js
@@ -2,12 +2,12 @@
 
 const Cloudfront = require('@aws-cdk/aws-cloudfront');
 const Route53 = require('@aws-cdk/aws-route53');
-const S3 = require('@aws-cdk/aws-s3');
 const S3deploy = require('@aws-cdk/aws-s3-deployment');
 const ACM = require('@aws-cdk/aws-certificatemanager');
 const CDK = require('@aws-cdk/core');
 const Targets = require('@aws-cdk/aws-route53-targets/lib');
 const Core = require('@aws-cdk/core');
+const { AutoDeleteBucket } = require('@mobileposse/auto-delete-bucket');
 
 /**
  * Static site infrastructure, which deploys site content to an S3 bucket.
@@ -23,7 +23,7 @@ class StaticSite extends Core.Construct {
         const siteDomain = props.siteSubDomain + '.' + props.domainName;
         new CDK.CfnOutput(this, 'Site', { value: 'https://' + siteDomain });
         // Content bucket
-        const siteBucket = new S3.Bucket(this, 'SiteBucket', {
+        const siteBucket = new AutoDeleteBucket(this, 'SiteBucket', {
             bucketName: siteDomain,
             websiteIndexDocument: 'index.html',
             websiteErrorDocument: 'index.html',

--- a/cdk/static-site.js
+++ b/cdk/static-site.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const Cloudfront = require('@aws-cdk/aws-cloudfront');
+const Route53 = require('@aws-cdk/aws-route53');
+const S3 = require('@aws-cdk/aws-s3');
+const S3deploy = require('@aws-cdk/aws-s3-deployment');
+const ACM = require('@aws-cdk/aws-certificatemanager');
+const CDK = require('@aws-cdk/core');
+const Targets = require('@aws-cdk/aws-route53-targets/lib');
+const Core = require('@aws-cdk/core');
+
+/**
+ * Static site infrastructure, which deploys site content to an S3 bucket.
+ *
+ * The site redirects from HTTP to HTTPS, using a CloudFront distribution,
+ * Route53 alias record, and ACM certificate.
+ */
+class StaticSite extends Core.Construct {
+    constructor(parent, name, props) {
+
+        super(parent, name);
+        const zone = Route53.HostedZone.fromLookup(this, 'Zone', { domainName: props.domainName });
+        const siteDomain = props.siteSubDomain + '.' + props.domainName;
+        new CDK.CfnOutput(this, 'Site', { value: 'https://' + siteDomain });
+        // Content bucket
+        const siteBucket = new S3.Bucket(this, 'SiteBucket', {
+            bucketName: siteDomain,
+            websiteIndexDocument: 'index.html',
+            websiteErrorDocument: 'index.html',
+            publicReadAccess: true,
+            // The default removal policy is RETAIN, which means that cdk destroy will not attempt to delete
+            // the new bucket, and it will remain in your account until manually deleted. By setting the policy to
+            // DESTROY, cdk destroy will attempt to delete the bucket, but will error if the bucket is not empty.
+            removalPolicy: CDK.RemovalPolicy.DESTROY
+        });
+        new CDK.CfnOutput(this, 'Bucket', { value: siteBucket.bucketName });
+        // TLS certificate
+        const certificateArn = new ACM.DnsValidatedCertificate(this, 'SiteCertificate', {
+            domainName: siteDomain,
+            hostedZone: zone
+        }).certificateArn;
+        new CDK.CfnOutput(this, 'Certificate', { value: certificateArn });
+        // CloudFront distribution that provides HTTPS
+        const distribution = new Cloudfront.CloudFrontWebDistribution(this, 'SiteDistribution', {
+            aliasConfiguration: {
+                acmCertRef: certificateArn,
+                names: [siteDomain],
+                sslMethod: Cloudfront.SSLMethod.SNI,
+                securityPolicy: Cloudfront.SecurityPolicyProtocol.TLS_V1_1_2016
+            },
+            originConfigs: [
+                {
+                    s3OriginSource: {
+                        s3BucketSource: siteBucket
+                    },
+                    behaviors: [{ isDefaultBehavior: true }]
+                }
+            ]
+        });
+        new CDK.CfnOutput(this, 'DistributionId', { value: distribution.distributionId });
+        // Route53 alias record for the CloudFront distribution
+        new Route53.ARecord(this, 'SiteAliasRecord', {
+            recordName: siteDomain,
+            target: Route53.AddressRecordTarget.fromAlias(new Targets.CloudFrontTarget(distribution)),
+            zone
+        });
+        // Deploy site contents to S3 bucket
+        new S3deploy.BucketDeployment(this, 'DeployWithInvalidation', {
+            sources: [S3deploy.Source.asset('./build')],
+            destinationBucket: siteBucket,
+            distribution,
+            distributionPaths: ['/*']
+        });
+    }
+}
+
+exports.StaticSite = StaticSite;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,13 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@aws-cdk/aws-certificatemanager": "^1.21.1",
+    "@aws-cdk/aws-cloudfront": "^1.21.1",
+    "@aws-cdk/aws-route53": "^1.21.1",
+    "@aws-cdk/aws-route53-targets": "^1.21.1",
+    "@aws-cdk/aws-s3": "^1.21.1",
+    "@aws-cdk/aws-s3-deployment": "^1.21.1",
+    "@aws-cdk/core": "^1.21.1",
     "@material-ui/core": "^4.5.2",
     "@material-ui/styles": "^4.5.2",
     "connected-react-router": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@aws-cdk/core": "^1.21.1",
     "@material-ui/core": "^4.5.2",
     "@material-ui/styles": "^4.5.2",
+    "@mobileposse/auto-delete-bucket": "^1.18.0",
     "connected-react-router": "^6.5.2",
     "history": "^4.10.1",
     "immer": "^5.0.0",


### PR DESCRIPTION
Adapted the [CDK Static-Site](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/static-site) example to deploy the built Strangeluv app to an S3 bucket, and serve it up with AWS Cloudfront.