### PR TITLE
Update material ui libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@mui/material": "5.10.x",
-    "@mui/styled-engine-sc": "5.10.x",
-    "@mui/styles": "5.10.x",
+    "@mui/material": "5.11.x",
+    "@mui/styled-engine-sc": "5.11.x",
+    "@mui/styles": "5.11.x",
     "connected-react-router": "6.x.x",
     "history": "^4.10.1",
     "immer": "9.x.x",


### PR DESCRIPTION
Safe updates: Material UI [v5.11.0](https://github.com/mui/material-ui/releases/tag/v5.11.0) had no breaking changes relevant to us.

Packages not updated
```
 history                       ^4.10.1  →   ^5.3.0     
 react                          17.x.x  →   18.x.x     
 react-dom                     ^17.0.2  →  ^18.2.0     
 react-redux                     7.x.x  →    8.x.x     
 react-router-dom                5.x.x  →    6.x.x     
 @testing-library/react         12.x.x  →   13.x.x     
 eslint-config-standard-react   12.x.x  →   13.x.x   
```

These are all tied to the big jump to React 18. 