### PR TITLE
add jsx quotes rule

### DIFF
--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -31,7 +31,8 @@ module.exports = {
         'react/jsx-uses-vars': 'warn',
         'react/react-in-jsx-scope': 'off',
         'react-hooks/exhaustive-deps': 'warn',
-        'react-hooks/rules-of-hooks': 'error'
+        'react-hooks/rules-of-hooks': 'error',
+        'jsx-quotes': ['error', 'prefer-single']
     },
     overrides: [
         {


### PR DESCRIPTION
Trello: https://trello.com/c/c5LAMw92

**Not sure if this would be a problem if you don't have Eslint extension

If you get this error:

<img width="1006" alt="Screen Shot 2023-01-19 at 4 20 19 PM" src="https://user-images.githubusercontent.com/91892796/213565311-d03acb92-b936-4a23-80e4-230f7fb8e4c0.png">

this error won't cause the app to crash or anything but it causes Eslint to not work properly.

What fixed it for me was setting `eslint.nodeEnv` in my vscode extension settings to `development`
