### PR TITLE
update eslint-webpack-plugin from v3 to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint-plugin-jsx-a11y": "6.x.x",
     "eslint-plugin-react": "7.x.x",
     "eslint-plugin-react-hooks": "4.x.x",
-    "eslint-webpack-plugin": "3.x.x",
+    "eslint-webpack-plugin": "4.x.x",
     "file-loader": "6.x.x",
     "html-webpack-plugin": "5.x.x",
     "jest": "29.x.x",


### PR DESCRIPTION
Only update needed was for `eslint-webpack-plugin v3 to v4`. [Breaking changes](https://github.com/webpack-contrib/eslint-webpack-plugin/blob/HEAD/CHANGELOG.md), where they dropped support for node v12 and eslint v7, doesn't affect us since we're using at least node v14 and eslint v8. The rest of the updates needed are all tied to us moving to React 18

```
 history                       ^4.10.1  →   ^5.3.0     
 react                          17.x.x  →   18.x.x     
 react-dom                     ^17.0.2  →  ^18.2.0     
 react-redux                     7.x.x  →    8.x.x     
 react-router-dom                5.x.x  →    6.x.x     
 @testing-library/react         12.x.x  →   14.x.x     
 eslint-config-standard-react   12.x.x  →   13.x.x 
```
