### PR TITLE
updated react-error-boundary to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prop-types": "^15.8.1",
     "react": "17.x.x",
     "react-dom": "^17.0.2",
-    "react-error-boundary": "3.x.x",
+    "react-error-boundary": "4.x.x",
     "react-hot-loader": "4.x.x",
     "react-redux": "7.x.x",
     "react-router-dom": "5.x.x",


### PR DESCRIPTION
I updated react-error-boundary. This was a major version update from version 3 to 4 but based on the release notes there didn't seem to be any breaking changes. Below are the remaining updates . The previous month's dev maintenance noted that  these  are related to upgrading to React version 18 . 
```
@testing-library/react         12.x.x  →   14.x.x
 eslint-config-standard-react   12.x.x  →   13.x.x
 history                       ^4.10.1  →   ^5.3.0
 react                          17.x.x  →   18.x.x
 react-dom                     ^17.0.2  →  ^18.2.0
 react-redux                     7.x.x  →    8.x.x
 react-router-dom                5.x.x  →    6.x.x   
```